### PR TITLE
add cloud sql proxy pattern as sidecar to notifications service for d…

### DIFF
--- a/charts/notification-service/templates/deployment.yaml
+++ b/charts/notification-service/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ required "serviceAccountName is required" .Values.serviceAccountName }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -128,6 +129,23 @@ spec:
               value: {{ required "apnsTownsAppIdentifier is required" .Values.apnsTownsAppIdentifier | quote }}
             - name: NOTIFICATIONS__WEBPUSH__VAPID__SUBJECT
               value: "support@towns.com"
+          - name: cloud-sql-proxy
+            image: "{{ .Values.cloudSqlProxy.image.repository }}:{{ .Values.cloudSqlProxy.image.tag }}"
+            imagePullPolicy: {{ .Values.cloudSqlProxy.image.pullPolicy }}
+            args:
+              # If connecting from a VPC-native GKE cluster, you can use the
+              # following flag to have the proxy connect over private IP
+              # - "--private-ip"
+              - "--auto-iam-authn"
+              # tcp should be set to the port the proxy should listen on
+              # and should match the DB_PORT value set above.
+              # Defaults: MySQL: 3306, Postgres: 5432, SQLServer: 1433
+              - "--port=5432"
+              - {{ required "instanceConnectionName is required" .Values.cloudSqlProxy.args.instanceConnectionName }}
+            securityContext:
+              # The default Cloud SQL proxy image runs as the
+              # "nonroot" user and group (uid: 65532) by default.
+              runAsNonRoot: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/notification-service/templates/service-account.yaml
+++ b/charts/notification-service/templates/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ required "serviceAccountName is required" .Values.serviceAccountName }}

--- a/charts/notification-service/values.yaml
+++ b/charts/notification-service/values.yaml
@@ -13,6 +13,18 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+cloudSqlProxy:
+  image:
+    repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+    pullPolicy: IfNotPresent
+    tag: ""
+  args:
+    # Cloud SQL instance connection name, e.g. hnt-argo-cd:us-central1:test-pg
+    # Format is PROJECT_ID:REGION:INSTANCE_ID
+    instanceConnectionName: ""
+
+serviceAccountName: ""
+
 # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 # This is to override the chart name.

--- a/environments/gamma/values.yaml
+++ b/environments/gamma/values.yaml
@@ -46,6 +46,16 @@ notificationService:
   image:
     tag: 33e06b3
   apnsTownsAppIdentifier: com.towns.internal
+  cloudSqlProxy:
+    image:
+      # It is recommended to use a specific version for production environments.
+      # See: https://github.com/GoogleCloudPlatform/cloudsql-proxy
+      tag: "latest"
+    args:
+      # todo: set this to the correct instance connection name
+      instanceConnectionName: hnt-live-gamma:us-central1:notifications-db-gamma
+  # todo: set this to the correct service account name
+  serviceAccountName: sa-notifications-service
 
 riverNode:
   image:


### PR DESCRIPTION
I've implemented a POC service (found at http://34.123.43.197/) for connecting a service in GKE to a CloudSQL postgres 16 db instance outside the cluster managed by GCP following the best practices described [here](https://cloud.google.com/sql/docs/postgres/connect-instance-kubernetes#go). This PR adds the a CloudSQL Proxy sidecar to the notifications service deployment and gamma values (some of which still need to be made concrete). To setup the notifications gamma service db follow this runbook:

1. Create a gcloud sql instance (terraform) - I created this from GCP dashboard in the hnt-argo-cd project named test-pg.
2A. Configure a Service Account for GKE such that it has Cloud SQL Client role with permissions to connect to Cloud SQL.
2B. Add IAM Policy Binding to SA, `roles/cloudsql.client`
3A. Create a Kubernetes service account resource configured to access CloudSQL via [Workload Identity Federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).

```
# [START cloud_sql_postgres_databasesql_gke_quickstart_sa]
apiVersion: v1
kind: ServiceAccount
metadata:
  name: ksa-cloud-sql # TODO(developer): replace this value
# [END cloud_sql_postgres_databasesql_gke_quickstart_sa]
```

```
kubectl apply -f service-account.yaml
```

3B. Run IAM Policy Binding to enable IAM binding of Google Service Account and K8s SA.
3C. Run `kubectl annotate` to annotate the K8s SA with IAM binding.

4. Configure secrets for db (I believe this is done already?)

5. Add concrete gamma values for `instanceConnectionName`, `serviceAccount` after creating the instance for CloudSql. 

ArgoCD should deploy the notifications service with CloudSql sidecar after the above and this pr is merged and the service thereafter should be able to connect to the CloudSQL db. 