### PR TITLE
New ExternalSecret for subgraph

### DIFF
--- a/charts/subgraph/templates/secrets.yaml
+++ b/charts/subgraph/templates/secrets.yaml
@@ -35,3 +35,42 @@ spec:
         key: subgraph-db-credentials
         property: root_password
         version: latest
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: subgraph-secondary-secrets
+  labels: {{- include "subgraph.labels" . | nindent 4 }}
+spec:
+  refreshInterval: "0"
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: base_chain_rpc_url
+      remoteRef:
+        key: subgraph_rpc_urls
+        property: base
+        version: latest
+
+    - secretKey: db_host
+      remoteRef:
+        key: subgraph-db-secondary-credentials
+        property: db_host
+        version: latest
+
+    - secretKey: db_user
+      remoteRef:
+        key: subgraph-db-secondary-credentials
+        property: root_user
+        version: latest
+
+    - secretKey: db_password
+      remoteRef:
+        key: subgraph-db-secondary-credentials
+        property: root_password
+        version: latest


### PR DESCRIPTION
Subgraph secondary secret as ExternalSecret managed by argo.
Will be used to facilitate migration to v11.