### PR TITLE
add env to xchain monitor logs

### DIFF
--- a/charts/xchain-monitor/templates/deployment.yaml
+++ b/charts/xchain-monitor/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: "info"
             - name: LOG_PRETTY
               value: "false"
+            - name: DD_TAGS
+              value: {{ .Values.ddTags | quote }}
             - name: BLOCK_SCAN_CHUNK_SIZE
               value: "10000"
       {{- with .Values.nodeSelector }}

--- a/environments/alpha/rendered/xchain-monitor.yaml
+++ b/environments/alpha/rendered/xchain-monitor.yaml
@@ -11,3 +11,5 @@ resources:
   requests:
     cpu: 0.4
     memory: 4Gi
+
+ddTags: "env:alpha, service: xchain-monitor"

--- a/environments/delta/rendered/xchain-monitor.yaml
+++ b/environments/delta/rendered/xchain-monitor.yaml
@@ -11,3 +11,5 @@ resources:
   requests:
     cpu: 0.4
     memory: 4Gi
+
+ddTags: "env:delta, service: xchain-monitor"

--- a/environments/gamma/rendered/xchain-monitor.yaml
+++ b/environments/gamma/rendered/xchain-monitor.yaml
@@ -11,3 +11,5 @@ resources:
   requests:
     cpu: 0.4
     memory: 4Gi
+
+ddTags: "env:gamma, service: xchain-monitor"

--- a/environments/omega/rendered/xchain-monitor.yaml
+++ b/environments/omega/rendered/xchain-monitor.yaml
@@ -11,3 +11,5 @@ resources:
   requests:
     cpu: 1
     memory: 5Gi
+
+ddTags: "env:omega, service: xchain-monitor"

--- a/templates/xchain-monitor.j2
+++ b/templates/xchain-monitor.j2
@@ -1,4 +1,8 @@
+{% set base_dd_tags = "env:" ~ global.environmentName ~ ", service: xchain-monitor" %}
+
 image:
   tag: "{{ xchainMonitor.image.tag }}"
 resources:
   {{ xchainMonitor.resources | to_yaml | indent(2) }}
+
+ddTags: "{{ base_dd_tags}}"


### PR DESCRIPTION
Adds env dd tag to xchain-monitor such that we can filter xchain monitor logs by env (alpha, gamma, omega...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added environment-specific tagging metadata for the xchain-monitor service, enabling improved monitoring and identification across different environments.
  - Deployment configuration now includes a new environment variable for enhanced observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->