### PR TITLE
Add requests limits for metrics-agg, adjust notification-service requ…

### DIFF
--- a/charts/metrics-aggregator/templates/deployment.yaml
+++ b/charts/metrics-aggregator/templates/deployment.yaml
@@ -65,6 +65,8 @@ spec:
           volumeMounts:
             - name: prometheus-etc
               mountPath: /river/packages/metrics-discovery/prometheus/etc
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
         - name: prometheus
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -77,6 +79,8 @@ spec:
           volumeMounts:
             - name: prometheus-etc
               mountPath: /prometheus/etc
+          resources:
+            {{- toYaml .Values.prometheus.resources | nindent 12 }}
           command:
             - /bin/prometheus
           args:

--- a/charts/metrics-aggregator/values.yaml
+++ b/charts/metrics-aggregator/values.yaml
@@ -27,6 +27,13 @@ prometheus:
     # httpGet: #TODO: fix this
     #   path: /
     #   port: http
+  resources:
+    limits:
+      cpu: 1.5
+      memory: 8Gi
+    requests:
+      cpu: 1
+      memory: 2Gi
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -56,6 +63,14 @@ podLabels: {}
 podSecurityContext:
   {}
   # fsGroup: 2000
+
+resources:
+  limits:
+    cpu: 1.5
+    memory: 5Gi
+  requests:
+    cpu: 1
+    memory: 2Gi
 
 securityContext:
   {}

--- a/environments/omega/rendered/notification-service.yaml
+++ b/environments/omega/rendered/notification-service.yaml
@@ -8,7 +8,7 @@ image:
 resources:
   limits:
     cpu: "1.5"
-    memory: 200Gi
+    memory: 180Gi
   requests:
     cpu: "1.5"
-    memory: 120Gi
+    memory: 80Gi

--- a/environments/omega/values.yaml
+++ b/environments/omega/values.yaml
@@ -20,10 +20,10 @@ notificationService:
   resources:
     limits:
       cpu: "1.5"
-      memory: "200Gi"
+      memory: "180Gi"
     requests:
       cpu: "1.5"
-      memory: "120Gi"
+      memory: "80Gi"
   apnsTownsAppIdentifier: com.towns.ios # TODO: always change
 
 riverNode:


### PR DESCRIPTION
Add request limits to metrics-aggregator (2 containers) so Node can schedule resources deterministically and prevent metrics-aggregator from being evicted by kubelet.

As part of this, also adjusted notifications service memory limits slightly lower to account for actual usage (~50gb mem) empirically.

This PR should prevent metrics-aggregator from being evicted due to OOM issues in k8s.

![Screenshot 2025-06-13 at 2 35 56 PM](https://github.com/user-attachments/assets/8fd5683b-519c-4212-9117-e7ba4955b537)
