### PR TITLE
Bump image and limits, subgraph

### DIFF
--- a/environments/gamma/rendered/subgraph.yaml
+++ b/environments/gamma/rendered/subgraph.yaml
@@ -11,7 +11,7 @@ podAnnotations:
 
 image:
   repository: "public.ecr.aws/h5v6m2x1/subgraph"
-  tag: "subgraph-v11-159f0d4c21"
+  tag: "3798da8"
   pullPolicy: "IfNotPresent"
 
 service:
@@ -24,10 +24,10 @@ secrets:
 
 resources:
   limits:
-    cpu: 1
+    cpu: 2.0
     memory: 20Gi
   requests:
-    cpu: 0.5
+    cpu: 1.5
     memory: 2Gi
 
 # Health checks

--- a/environments/gamma/values.yaml
+++ b/environments/gamma/values.yaml
@@ -41,17 +41,17 @@ riverNode:
 
 subgraph:
   image:
-    tag: "subgraph-v11-159f0d4c21"
+    tag: "3798da8"
   ponderStartBlock: "9378183"
   nodeEnv: "development"
   secrets:
     name: "subgraph-secondary-secrets"
   resources:
     requests:
-      cpu: 0.5
+      cpu: 1.5
       memory: 2Gi
     limits:
-      cpu: 1
+      cpu: 2.0
       memory: 20Gi
 
 appRegistryService:


### PR DESCRIPTION
Bump image for gamma to latest with v11 and enabled cache.