### PR TITLE
bump subgraph images

### DIFF
--- a/environments/gamma/rendered/subgraph.yaml
+++ b/environments/gamma/rendered/subgraph.yaml
@@ -12,7 +12,7 @@ podAnnotations:
 
 image:
   repository: "public.ecr.aws/h5v6m2x1/subgraph"
-  tag: "49d065a"
+  tag: "9ed65e0"
   pullPolicy: "IfNotPresent"
 
 service:

--- a/environments/gamma/rendered/subgraph.yaml
+++ b/environments/gamma/rendered/subgraph.yaml
@@ -12,7 +12,7 @@ podAnnotations:
 
 image:
   repository: "public.ecr.aws/h5v6m2x1/subgraph"
-  tag: "9ed65e0"
+  tag: "subgraph-61825-de4693cadb"
   pullPolicy: "IfNotPresent"
 
 service:

--- a/environments/gamma/values.yaml
+++ b/environments/gamma/values.yaml
@@ -41,7 +41,7 @@ riverNode:
 
 subgraph:
   image:
-    tag: "9ed65e0"
+    tag: "subgraph-61825-de4693cadb"
   ponderStartBlock: "9378183"
   ponderLogLevel: "debug"
   nodeEnv: "development"

--- a/environments/gamma/values.yaml
+++ b/environments/gamma/values.yaml
@@ -41,7 +41,7 @@ riverNode:
 
 subgraph:
   image:
-    tag: "49d065a"
+    tag: "9ed65e0"
   ponderStartBlock: "9378183"
   ponderLogLevel: "debug"
   nodeEnv: "development"

--- a/environments/omega/rendered/subgraph.yaml
+++ b/environments/omega/rendered/subgraph.yaml
@@ -12,7 +12,7 @@ podAnnotations:
 
 image:
   repository: "public.ecr.aws/h5v6m2x1/subgraph"
-  tag: "subgraph-49d065a-2"
+  tag: "9ed65e0"
   pullPolicy: "IfNotPresent"
 
 service:

--- a/environments/omega/rendered/subgraph.yaml
+++ b/environments/omega/rendered/subgraph.yaml
@@ -12,7 +12,7 @@ podAnnotations:
 
 image:
   repository: "public.ecr.aws/h5v6m2x1/subgraph"
-  tag: "9ed65e0"
+  tag: "subgraph-61825-de4693cadb"
   pullPolicy: "IfNotPresent"
 
 service:

--- a/environments/omega/values.yaml
+++ b/environments/omega/values.yaml
@@ -49,7 +49,7 @@ riverNode:
 
 subgraph:
   image:
-    tag: "subgraph-49d065a-2"
+    tag: "9ed65e0"
   ponderStartBlock: "13777757"
   ponderLogLevel: "info"
   nodeEnv: "production"

--- a/environments/omega/values.yaml
+++ b/environments/omega/values.yaml
@@ -49,7 +49,7 @@ riverNode:
 
 subgraph:
   image:
-    tag: "9ed65e0"
+    tag: "subgraph-61825-de4693cadb"
   ponderStartBlock: "13777757"
   ponderLogLevel: "info"
   nodeEnv: "production"


### PR DESCRIPTION
bump subgraph images - to deploy staking https://github.com/towns-protocol/towns/pull/3333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the subgraph service to use the latest container image in both gamma and omega environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->