### PR TITLE
Revert "Test bad image in omega to see if it reproduces on alpha."

### DIFF
--- a/environments/alpha/rendered/notification-service.yaml
+++ b/environments/alpha/rendered/notification-service.yaml
@@ -4,7 +4,7 @@
 
 apnsTownsAppIdentifier: com.towns.ios.alpha
 image:
-  tag: "ab65192"
+  tag: "0dd86e9"
 resources:
   limits:
     cpu: 1000m

--- a/environments/alpha/values.yaml
+++ b/environments/alpha/values.yaml
@@ -16,7 +16,7 @@ chains:
 
 notificationService:
   image:
-    tag: "ab65192"
+    tag: "0dd86e9"
   resources:
     requests:
       cpu: 1000m


### PR DESCRIPTION
Reverts HereNotThere/argocd#53

The bad omega commit does in fact work in alpha.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the notification service to use the latest version in the alpha environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->