### PR TITLE
bump omega subgraph image

### DIFF
--- a/environments/omega/rendered/subgraph.yaml
+++ b/environments/omega/rendered/subgraph.yaml
@@ -12,7 +12,7 @@ podAnnotations:
 
 image:
   repository: "public.ecr.aws/h5v6m2x1/subgraph"
-  tag: "subgraph-61825-de4693cadb"
+  tag: "135a69c"
   pullPolicy: "IfNotPresent"
 
 service:

--- a/environments/omega/values.yaml
+++ b/environments/omega/values.yaml
@@ -49,7 +49,7 @@ riverNode:
 
 subgraph:
   image:
-    tag: "subgraph-61825-de4693cadb"
+    tag: "135a69c"
   ponderStartBlock: "13777757"
   ponderLogLevel: "info"
   nodeEnv: "production"


### PR DESCRIPTION
bump omega subgraph image to commit hash 135a69c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the subgraph service image version used in the deployment configuration. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->