### PR TITLE
add subgraph to update_infra ci job

### DIFF
--- a/.github/workflows/update_infra.yml
+++ b/.github/workflows/update_infra.yml
@@ -21,16 +21,19 @@ on:
         description: "riverNode.image.tag"
         type: string
         required: false
-
       appRegistryServiceImageTag:
         description: "appRegistryService.image.tag"
         type: string
         required: false
-
       rpcGatewayImageTag:
         description: "rpcGateway.image.tag"
         type: string
         required: false
+      subgraphImageTag:
+        description: "subgraph.image.tag"
+        type: string
+        required: false
+
   repository_dispatch:
     types: [update-infra]
 
@@ -73,6 +76,7 @@ jobs:
             RIVER_NODE_IMAGE_TAG="${{ github.event.inputs.riverNodeImageTag }}"
             APP_REGISTRY_SERVICE_IMAGE_TAG="${{ github.event.inputs.appRegistryServiceImageTag }}"
             RPC_GATEWAY_IMAGE_TAG="${{ github.event.inputs.rpcGatewayImageTag }}"
+            SUBGRAPH_IMAGE_TAG="${{ github.event.inputs.subgraphImageTag }}"
 
           elif [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
             echo "Repository dispatch event detected"
@@ -81,6 +85,7 @@ jobs:
             RIVER_NODE_IMAGE_TAG="${{ github.event.client_payload.riverNodeImageTag }}"
             APP_REGISTRY_SERVICE_IMAGE_TAG="${{ github.event.client_payload.appRegistryServiceImageTag }}"
             RPC_GATEWAY_IMAGE_TAG="${{ github.event.client_payload.rpcGatewayImageTag }}"
+            SUBGRAPH_IMAGE_TAG="${{ github.event.client_payload.subgraphImageTag }}"
           else
             echo "Unknown event type: ${{ github.event_name }}, exiting"
             exit 1
@@ -112,6 +117,11 @@ jobs:
           # if the rpc gateway tag is set
           if [[ -n "$RPC_GATEWAY_IMAGE_TAG" ]]; then
             VALUES="$VALUES rpcGateway.image.tag=$RPC_GATEWAY_IMAGE_TAG"
+          fi
+
+          # if the subgraph tag is set
+          if [[ -n "$SUBGRAPH_IMAGE_TAG" ]]; then
+            VALUES="$VALUES subgraph.image.tag=$SUBGRAPH_IMAGE_TAG"
           fi
 
           echo "VALUES=${VALUES}" >> $GITHUB_ENV


### PR DESCRIPTION
Will update subgraph in argocd with new image (if different from current deployed image) rendering new template with updated image for the requested environment. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional subgraph image tag parameter when manually triggering or dispatching the infrastructure update workflow. This allows users to specify a custom subgraph image tag during workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->