### PR TITLE
Update river node template to require app registry contract configuration, configure for alpha.

### DIFF
--- a/charts/app-registry-service/templates/deployment.yaml
+++ b/charts/app-registry-service/templates/deployment.yaml
@@ -113,6 +113,8 @@ spec:
               value: {{ required "riverRegistry contract address required" $.Values.global.chains.river.contractAddresses.riverRegistry }}
             - name: ENTITLEMENT_CONTRACT__ADDRESS
               value: {{ required "baseRegistry contract address required" $.Values.global.chains.base.contractAddresses.baseRegistry }}
+            - name: APPREGISTRYCONTRACT__ADDRESS
+              value: {{ required "appRegistry contract address required" $.Values.global.chains.base.contractAddresses.appRegistry }}
 
             - name: LOG__FORMAT
               value: json

--- a/environments/alpha/rendered/global.yaml
+++ b/environments/alpha/rendered/global.yaml
@@ -14,6 +14,7 @@ global:
     base:
       chainId: "84532"
       contractAddresses:
+        appRegistry: "0x23a9f5AbBcC82d1E2B5C0781b1F05F2B623E2c69"
         baseRegistry: "0x0230a9d28bc48a90d6f5e5112b24319ec1b14c52"
         spaceArchitect: "0xC09Ac0FFeecAaE5100158247512DC177AeacA3e3"
     river:

--- a/environments/alpha/values.yaml
+++ b/environments/alpha/values.yaml
@@ -13,6 +13,7 @@ chains:
     contractAddresses:
       spaceArchitect: "0xC09Ac0FFeecAaE5100158247512DC177AeacA3e3"
       baseRegistry: "0x0230a9d28bc48a90d6f5e5112b24319ec1b14c52"
+      appRegistry: "0x23a9f5AbBcC82d1E2B5C0781b1F05F2B623E2c69"
 
 notificationService:
   image:


### PR DESCRIPTION
This will break deployment for other environments until we configure them, but it should unblock testing on alpha.