### PR TITLE
Jt/add xchain to argo apps

### DIFF
--- a/.github/workflows/update_infra.yml
+++ b/.github/workflows/update_infra.yml
@@ -33,6 +33,10 @@ on:
         description: "subgraph.image.tag"
         type: string
         required: false
+      xchainMonitorImageTag:
+        description: "xchainMonitor.image.tag"
+        type: string
+        required: false
 
   repository_dispatch:
     types: [update-infra]
@@ -77,7 +81,7 @@ jobs:
             APP_REGISTRY_SERVICE_IMAGE_TAG="${{ github.event.inputs.appRegistryServiceImageTag }}"
             RPC_GATEWAY_IMAGE_TAG="${{ github.event.inputs.rpcGatewayImageTag }}"
             SUBGRAPH_IMAGE_TAG="${{ github.event.inputs.subgraphImageTag }}"
-
+            XCHAIN_MONITOR_IMAGE_TAG="${{ github.event.inputs.xchainMonitorImageTag }}"
           elif [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
             echo "Repository dispatch event detected"
             ENV="${{ github.event.client_payload.environment }}"
@@ -86,6 +90,7 @@ jobs:
             APP_REGISTRY_SERVICE_IMAGE_TAG="${{ github.event.client_payload.appRegistryServiceImageTag }}"
             RPC_GATEWAY_IMAGE_TAG="${{ github.event.client_payload.rpcGatewayImageTag }}"
             SUBGRAPH_IMAGE_TAG="${{ github.event.client_payload.subgraphImageTag }}"
+            XCHAIN_MONITOR_IMAGE_TAG="${{ github.event.client_payload.xchainMonitorImageTag }}"
           else
             echo "Unknown event type: ${{ github.event_name }}, exiting"
             exit 1
@@ -122,6 +127,11 @@ jobs:
           # if the subgraph tag is set
           if [[ -n "$SUBGRAPH_IMAGE_TAG" ]]; then
             VALUES="$VALUES subgraph.image.tag=$SUBGRAPH_IMAGE_TAG"
+          fi
+
+          # if the xchain monitor tag is set
+          if [[ -n "$XCHAIN_MONITOR_IMAGE_TAG" ]]; then
+            VALUES="$VALUES xchainMonitor.image.tag=$XCHAIN_MONITOR_IMAGE_TAG"
           fi
 
           echo "VALUES=${VALUES}" >> $GITHUB_ENV

--- a/environments/alpha/rendered/app-of-apps.yaml
+++ b/environments/alpha/rendered/app-of-apps.yaml
@@ -62,7 +62,7 @@ appOfApps:
         - ../../environments/alpha/rendered/main-alb.yaml
 
     - name: xchain-monitor
-      disable: true
+      disable: false
       namespace: default
       valueFiles:
         - ./values.yaml

--- a/environments/alpha/values.yaml
+++ b/environments/alpha/values.yaml
@@ -129,7 +129,7 @@ appOfApps:
     disable: false
   - name: xchain-monitor
     namespace: default
-    disable: true
+    disable: false
   - name: metrics-aggregator
     namespace: default
     disable: false

--- a/environments/gamma/rendered/app-of-apps.yaml
+++ b/environments/gamma/rendered/app-of-apps.yaml
@@ -62,7 +62,7 @@ appOfApps:
         - ../../environments/gamma/rendered/main-alb.yaml
 
     - name: xchain-monitor
-      disable: true
+      disable: false
       namespace: default
       valueFiles:
         - ./values.yaml

--- a/environments/gamma/values.yaml
+++ b/environments/gamma/values.yaml
@@ -124,7 +124,7 @@ appOfApps:
     disable: false
   - name: xchain-monitor
     namespace: default
-    disable: true
+    disable: false
   - name: metrics-aggregator
     namespace: default
     disable: false


### PR DESCRIPTION
- enables xchain-monitor service in app of apps for alpha, gamma and update ci job to allow deploys of new images by tag for all environments in argo.