### PR TITLE
Disable monitors on non-omega environments 

### DIFF
--- a/environments/alpha/rendered/app-of-apps.yaml
+++ b/environments/alpha/rendered/app-of-apps.yaml
@@ -62,7 +62,7 @@ appOfApps:
         - ../../environments/alpha/rendered/main-alb.yaml
 
     - name: xchain-monitor
-      disable: false
+      disable: true
       namespace: default
       valueFiles:
         - ./values.yaml

--- a/environments/alpha/values.yaml
+++ b/environments/alpha/values.yaml
@@ -130,7 +130,7 @@ appOfApps:
     disable: false
   - name: xchain-monitor
     namespace: default
-    disable: false
+    disable: true
   - name: metrics-aggregator
     namespace: default
     disable: false

--- a/environments/gamma/rendered/app-of-apps.yaml
+++ b/environments/gamma/rendered/app-of-apps.yaml
@@ -62,7 +62,7 @@ appOfApps:
         - ../../environments/gamma/rendered/main-alb.yaml
 
     - name: xchain-monitor
-      disable: false
+      disable: true
       namespace: default
       valueFiles:
         - ./values.yaml

--- a/environments/gamma/values.yaml
+++ b/environments/gamma/values.yaml
@@ -125,7 +125,7 @@ appOfApps:
     disable: false
   - name: xchain-monitor
     namespace: default
-    disable: false
+    disable: true
   - name: metrics-aggregator
     namespace: default
     disable: false


### PR DESCRIPTION
...because they are causing alerts in datadog since they don't have env tags. The errors emitted as the service restarts are not occuring on omega, but we cannot filter by environment to disclude these from the monitor.