### PR TITLE
Unpin image tag on 3rd archiver node.

### DIFF
--- a/environments/omega/rendered/river-node.yaml
+++ b/environments/omega/rendered/river-node.yaml
@@ -81,7 +81,7 @@ nodes:
     nodeUrl: https://archive3.nodes.omega.towns.com
     migrationStatus: done
     image:
-      tag: "589d4f8"
+      tag: "bb91fbb"
 
 race: false
 

--- a/environments/omega/values.yaml
+++ b/environments/omega/values.yaml
@@ -34,9 +34,6 @@ riverNode:
   useRpcGateway: true
   numStreamNodes: 3
   numArchiveNodes: 3
-  imageTagOverride:
-    archive:
-      3: "589d4f8"
 
   apmEnabled: true
   resources:


### PR DESCRIPTION
3rd archiver is on an image that continuously polls unavailable streams. We've already migrated these streams, so let's unpin this image and reduce error logs.