### PR TITLE
disable app-reg omega temporarily to update ingress

### DIFF
--- a/charts/main-alb/templates/_helpers.tpl
+++ b/charts/main-alb/templates/_helpers.tpl
@@ -109,6 +109,23 @@ Notification Sendit domain name
 All host names to attach to the ALB. A comma separated list of all the host names that should be attached to the ALB.
 */}}
 {{- define "main-alb.hosts" -}}
-{{ include "argocd.domainName" . }},{{ include "notification-service.domainName" . }},{{ include "subgraph.domainName" . }},{{ include "rpc-gateway.domainName" . }},{{ include "app-registry-service.domainName" . }},{{ include "notification-sendit.domainName" . }}
+{{- $hosts := list -}}
+{{- $hosts = append $hosts (include "argocd.domainName" .) -}}
+{{- if not .Values.notificationService.disable -}}
+{{- $hosts = append $hosts (include "notification-service.domainName" .) -}}
+{{- end -}}
+{{- if not .Values.subgraph.disable -}}
+{{- $hosts = append $hosts (include "subgraph.domainName" .) -}}
+{{- end -}}
+{{- if not .Values.rpcGateway.disable -}}
+{{- $hosts = append $hosts (include "rpc-gateway.domainName" .) -}}
+{{- end -}}
+{{- if not .Values.appRegistryService.disable -}}
+{{- $hosts = append $hosts (include "app-registry-service.domainName" .) -}}
+{{- end -}}
+{{- if not .Values.notificationSendit.disable -}}
+{{- $hosts = append $hosts (include "notification-sendit.domainName" .) -}}
+{{- end -}}
+{{- join "," $hosts -}}
 {{- end }}
 

--- a/charts/main-alb/templates/ingress.yaml
+++ b/charts/main-alb/templates/ingress.yaml
@@ -11,12 +11,22 @@ spec:
     name: letsencrypt
     kind: ClusterIssuer
   dnsNames:
+    {{- if not .Values.notificationService.disable }}
     - {{ include "notification-service.domainName" . }}
+    {{- end }}
     - {{ include "argocd.domainName" . }}
+    {{- if not .Values.subgraph.disable }}
     - {{ include "subgraph.domainName" . }}
+    {{- end }}
+    {{- if not .Values.rpcGateway.disable }}
     - {{ include "rpc-gateway.domainName" . }}
+    {{- end }}
+    {{- if not .Values.appRegistryService.disable }}
     - {{ include "app-registry-service.domainName" . }}
+    {{- end }}
+    {{- if not .Values.notificationSendit.disable }}
     - {{ include "notification-sendit.domainName" . }}
+    {{- end }}
 
 ---
 
@@ -33,12 +43,22 @@ metadata:
 spec:
   tls:
     - hosts:
+        {{- if not .Values.notificationService.disable }}
         - {{ include "notification-service.domainName" . }}
+        {{- end }}
         - {{ include "argocd.domainName" . }}
+        {{- if not .Values.subgraph.disable }}
         - {{ include "subgraph.domainName" . }}
+        {{- end }}
+        {{- if not .Values.rpcGateway.disable }}
         - {{ include "rpc-gateway.domainName" . }}
+        {{- end }}
+        {{- if not .Values.appRegistryService.disable }}
         - {{ include "app-registry-service.domainName" . }}
+        {{- end }}
+        {{- if not .Values.notificationSendit.disable }}
         - {{ include "notification-sendit.domainName" . }}
+        {{- end }}
       secretName: main-alb-tls
   rules:
     {{- if not .Values.notificationService.disable }}

--- a/environments/omega/rendered/app-of-apps.yaml
+++ b/environments/omega/rendered/app-of-apps.yaml
@@ -110,7 +110,7 @@ appOfApps:
         - ../../environments/omega/rendered/rpc-gateway.yaml
 
     - name: app-registry-service
-      disable: false
+      disable: true
       namespace: default
       valueFiles:
         - ./values.yaml

--- a/environments/omega/rendered/main-alb.yaml
+++ b/environments/omega/rendered/main-alb.yaml
@@ -12,7 +12,7 @@ rpcGateway:
   disable: false
 
 appRegistryService:
-  disable: false
+  disable: true
 
 notificationSendit:
   disable: false

--- a/environments/omega/values.yaml
+++ b/environments/omega/values.yaml
@@ -166,7 +166,7 @@ appOfApps:
     disable: false
   - name: app-registry-service
     namespace: default
-    disable: false
+    disable: true
   - name: notification-sendit
     namespace: default
     disable: false


### PR DESCRIPTION
We need to update ingress and remove app-registry until the service is fully up and running in order to apply changes to the ingress controller, namely the introduction of notification-sendit service and updated tls cert.

We will re-introduce the app-registry to the main-alb once that service is fully operational in the cluster. 


```
(.venv) ➜  argocd git:(jt/remove-app-registry-from-main-alb) ✗ kubectl describe ingress main-alb                             
Name:             main-alb
Labels:           app.kubernetes.io/instance=main-alb
                  app.kubernetes.io/managed-by=Helm
                  app.kubernetes.io/name=main-alb
                  app.kubernetes.io/version=1.16.0
                  argocd.argoproj.io/instance=main-alb
                  helm.sh/chart=main-alb-0.1.0
Namespace:        default
Address:          34.110.147.216
Ingress Class:    <none>
Default backend:  <default>
TLS:
  main-alb-tls terminates river-notification-service-omega.towns.com,argocd-omega.towns.com,subgraph-omega.towns.com,rpc-gateway-omega.towns.com,app-registry.omega.towns.com,notification-sendit-omega.towns.com
Rules:
  Host                                        Path  Backends
  ----                                        ----  --------
  river-notification-service-omega.towns.com  
                                              /   notification-service:80 (10.2.1.114:80)
  app-registry.omega.towns.com                
                                              /   app-registry-service:80 (<error: services "app-registry-service" not found>)
  argocd-omega.towns.com                      
                                              /   nginx-argocd-wrapper:80 (10.2.5.25:80)
  subgraph-omega.towns.com                    
                                              /   subgraph:80 (10.2.0.102:42069)
  rpc-gateway-omega.towns.com                 
                                              /   rpc-gateway:8080 (10.2.1.14:8080)
  notification-sendit-omega.towns.com         
                                              /   notification-sendit:80 (10.2.1.112:80)
Annotations:                                  external-dns.alpha.kubernetes.io/hostname:
                                                argocd-omega.towns.com,river-notification-service-omega.towns.com,subgraph-omega.towns.com,rpc-gateway-omega.towns.com,app-registry.omega....
                                              ingress.kubernetes.io/backends:
                                                {"k8s1-8ceb687d-default-nginx-argocd-wrapper-80-bb86fe38":"HEALTHY","k8s1-8ceb687d-default-notification-service-80-68b1f612":"HEALTHY","k8...
                                              ingress.kubernetes.io/https-forwarding-rule: k8s2-fs-rmi33thx-default-main-alb-l3gfa22t
                                              ingress.kubernetes.io/https-target-proxy: k8s2-ts-rmi33thx-default-main-alb-l3gfa22t
                                              ingress.kubernetes.io/ssl-cert: k8s2-cr-rmi33thx-e7yxypg5py0x1gbj-a376f3adb01ea47f
                                              ingress.kubernetes.io/url-map: k8s2-um-rmi33thx-default-main-alb-l3gfa22t
                                              kubernetes.io/ingress.allow-http: false
                                              kubernetes.io/ingress.class: gce
                                              kubernetes.io/ingress.global-static-ip-name: main-alb-ip
Events:
  Type     Reason     Age                   From                     Message
  ----     ------     ----                  ----                     -------
  Warning  Translate  10m (x135 over 12h)   loadbalancer-controller  Translation failed: invalid ingress spec: could not find service "default/app-registry-service"
  Normal   Sync       4m58s (x76 over 12h)  loadbalancer-controller  Scheduled for sync
```
