### PR TITLE
NET-279 update omega trackback to crash level

### DIFF
--- a/environments/omega/rendered/river-node.yaml
+++ b/environments/omega/rendered/river-node.yaml
@@ -87,7 +87,7 @@ race: false
 
 logLevel: info
 
-gotraceback: all
+gotraceback: crash
 
 resources:
   limits:

--- a/environments/omega/values.yaml
+++ b/environments/omega/values.yaml
@@ -47,7 +47,7 @@ riverNode:
   numStreamNodes: 3
   numArchiveNodes: 3
 
-  gotraceback: "all"
+  gotraceback: "crash"
   apmEnabled: true
   resources:
     requests:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to limit Go runtime tracebacks to only display on crashes instead of all errors or panics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->