### PR TITLE
NET-279 update TOWNS_GOTRACEBACK when traceback value is set

### DIFF
--- a/charts/river-node/templates/deployment.yaml
+++ b/charts/river-node/templates/deployment.yaml
@@ -171,6 +171,8 @@ spec:
             {{- if $.Values.gotraceback }}
             - name: GOTRACEBACK
               value: {{ $.Values.gotraceback | quote }}
+            - name: TOWNS_GOTRACEBACK
+              value: {{ $.Values.gotraceback | quote }}
             {{- end }}
       volumes:
         - name: tls-secret


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new environment variable for deployments, ensuring both `GOTRACEBACK` and `TOWNS_GOTRACEBACK` are set when applicable. No other deployment settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->