### PR TITLE
Specific log settings for notification services, enable debug for sendit on omega

### DIFF
--- a/charts/notification-sendit/templates/deployment.yaml
+++ b/charts/notification-sendit/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: LOG__FORMAT
               value: json
             - name: LOG__LEVEL
-              value: info
+              value: {{ $.Values.logLevel | quote }}
             - name: LOG__NOCOLOR
               value: "true"
             - name: RUN_MODE

--- a/charts/notification-service/templates/deployment.yaml
+++ b/charts/notification-service/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: LOG__FORMAT
               value: json
             - name: LOG__LEVEL
-              value: info
+              value: {{ $.Values.logLevel | quote }}
             - name: LOG__NOCOLOR
               value: "true"
             - name: RUN_MODE

--- a/environments/alpha/rendered/notification-sendit.yaml
+++ b/environments/alpha/rendered/notification-sendit.yaml
@@ -12,3 +12,5 @@ resources:
   requests:
     cpu: 500m
     memory: 2Gi
+
+logLevel: info

--- a/environments/alpha/rendered/notification-service.yaml
+++ b/environments/alpha/rendered/notification-service.yaml
@@ -12,3 +12,5 @@ resources:
   requests:
     cpu: 1000m
     memory: 7.5Gi
+
+logLevel: info

--- a/environments/delta/rendered/notification-sendit.yaml
+++ b/environments/delta/rendered/notification-sendit.yaml
@@ -12,3 +12,5 @@ resources:
   requests:
     cpu: 500m
     memory: 2Gi
+
+logLevel: info

--- a/environments/delta/rendered/notification-service.yaml
+++ b/environments/delta/rendered/notification-service.yaml
@@ -12,3 +12,5 @@ resources:
   requests:
     cpu: 1
     memory: 7.5Gi
+
+logLevel: info

--- a/environments/gamma/rendered/notification-sendit.yaml
+++ b/environments/gamma/rendered/notification-sendit.yaml
@@ -12,3 +12,5 @@ resources:
   requests:
     cpu: 0.5
     memory: 2Gi
+
+logLevel: info

--- a/environments/gamma/rendered/notification-service.yaml
+++ b/environments/gamma/rendered/notification-service.yaml
@@ -12,3 +12,5 @@ resources:
   requests:
     cpu: 1
     memory: 7Gi
+
+logLevel: info

--- a/environments/omega/rendered/notification-sendit.yaml
+++ b/environments/omega/rendered/notification-sendit.yaml
@@ -12,3 +12,5 @@ resources:
   requests:
     cpu: 0.5
     memory: 10Gi
+
+logLevel: debug

--- a/environments/omega/rendered/notification-service.yaml
+++ b/environments/omega/rendered/notification-service.yaml
@@ -12,3 +12,5 @@ resources:
   requests:
     cpu: 1.5
     memory: 80Gi
+
+logLevel: info

--- a/environments/omega/values.yaml
+++ b/environments/omega/values.yaml
@@ -37,6 +37,7 @@ notificationSendit:
       cpu: 0.5
       memory: 10Gi
   apnsTownsAppIdentifier: earth.sendit.app
+  logLevel: debug
 
 riverNode:
   image:

--- a/templates/notification-sendit.j2
+++ b/templates/notification-sendit.j2
@@ -3,3 +3,5 @@ image:
   tag: "{{ notificationSendit.image.tag }}"
 resources:
   {{ notificationSendit.resources | to_yaml | indent(2) }}
+
+logLevel: {{ notificationSendit.logLevel | default('info') | lower }}

--- a/templates/notification-service.j2
+++ b/templates/notification-service.j2
@@ -3,3 +3,5 @@ image:
   tag: "{{ notificationService.image.tag }}"
 resources:
   {{ notificationService.resources | to_yaml | indent(2) }}
+
+logLevel: {{ notificationService.logLevel | default('info') | lower }}


### PR DESCRIPTION
This PR establishes the option to set log settings for specific notification services on various environments, and specifically sets the value for the SendIt service on omega to `debug`. 