### PR TITLE
NET-275 use client IP in argocd nginx wrapper

### DIFF
--- a/charts/main-alb/templates/argocd-nginx.yaml
+++ b/charts/main-alb/templates/argocd-nginx.yaml
@@ -14,7 +14,7 @@ data:
       {{- range .Values.argocdProxy.trustedProxies.cidrBlocks }}
       set_real_ip_from {{ . }};
       {{- end }}
-      
+
       # Use the X-Forwarded-For header to get the real client IP, and not Load Balancer IP
       real_ip_header X-Forwarded-For;
       real_ip_recursive on;

--- a/charts/main-alb/templates/argocd-nginx.yaml
+++ b/charts/main-alb/templates/argocd-nginx.yaml
@@ -10,12 +10,10 @@ data:
     }
     http {
       # Configure nginx to get real client IP from X-Forwarded-For header
-      # These are Google Cloud Load Balancer IP ranges
-      set_real_ip_from 35.191.0.0/16;
-      set_real_ip_from 130.211.0.0/22;
-      set_real_ip_from 35.235.240.0/20;
-      set_real_ip_from 209.85.152.0/22;
-      set_real_ip_from 209.85.204.0/22;
+      # Trusted Google Cloud Load Balancer IP ranges
+      {{- range .Values.argocdProxy.trustedProxies }}
+            set_real_ip_from {{ . }};
+      {{- end }}
 
       # Use the X-Forwarded-For header to get the real client IP, and not Load Balancer IP
       real_ip_header X-Forwarded-For;

--- a/charts/main-alb/templates/argocd-nginx.yaml
+++ b/charts/main-alb/templates/argocd-nginx.yaml
@@ -9,6 +9,18 @@ data:
       worker_connections 1024;
     }
     http {
+      # Configure nginx to get real client IP from X-Forwarded-For header
+      # These are Google Cloud Load Balancer IP ranges
+      set_real_ip_from 35.191.0.0/16;
+      set_real_ip_from 130.211.0.0/22;
+      set_real_ip_from 35.235.240.0/20;
+      set_real_ip_from 209.85.152.0/22;
+      set_real_ip_from 209.85.204.0/22;
+
+      # Use the X-Forwarded-For header to get the real client IP, and not Load Balancer IP
+      real_ip_header X-Forwarded-For;
+      real_ip_recursive on;
+
       {{- if .Values.argocdProxy.rateLimiting.enabled }}
       # Rate limits per IP
       limit_req_zone $binary_remote_addr zone=general:2m rate={{ .Values.argocdProxy.rateLimiting.general.rate }}r/s;

--- a/charts/main-alb/templates/argocd-nginx.yaml
+++ b/charts/main-alb/templates/argocd-nginx.yaml
@@ -9,17 +9,18 @@ data:
       worker_connections 1024;
     }
     http {
+      {{- if .Values.argocdProxy.trustedProxies.enabled }}
       # Configure nginx to get real client IP from X-Forwarded-For header
-      # Trusted Google Cloud Load Balancer IP ranges
-      {{- range .Values.argocdProxy.trustedProxies }}
-            set_real_ip_from {{ . }};
+      {{- range .Values.argocdProxy.trustedProxies.cidrBlocks }}
+      set_real_ip_from {{ . }};
       {{- end }}
-
+      
       # Use the X-Forwarded-For header to get the real client IP, and not Load Balancer IP
       real_ip_header X-Forwarded-For;
       real_ip_recursive on;
+      {{- end }}
 
-      {{- if .Values.argocdProxy.rateLimiting.enabled }}
+      {{ if .Values.argocdProxy.rateLimiting.enabled }}
       # Rate limits per IP
       limit_req_zone $binary_remote_addr zone=general:2m rate={{ .Values.argocdProxy.rateLimiting.general.rate }}r/s;
       limit_req_zone $binary_remote_addr zone=webhook:2m rate={{ .Values.argocdProxy.rateLimiting.webhook.rate }}r/s;

--- a/charts/main-alb/values.yaml
+++ b/charts/main-alb/values.yaml
@@ -1,6 +1,8 @@
 # ArgoCD proxy default rate limiting configuration
 argocdProxy:
   trustedProxies:
+    enabled: false
+    cidrBlocks:
     - 35.191.0.0/16
     - 130.211.0.0/22
     - 35.235.240.0/20

--- a/charts/main-alb/values.yaml
+++ b/charts/main-alb/values.yaml
@@ -1,5 +1,11 @@
 # ArgoCD proxy default rate limiting configuration
 argocdProxy:
+  trustedProxies:
+    - 35.191.0.0/16
+    - 130.211.0.0/22
+    - 35.235.240.0/20
+    - 209.85.152.0/22
+    - 209.85.204.0/22
   rateLimiting:
     enabled: false
     general:

--- a/environments/alpha/rendered/main-alb.yaml
+++ b/environments/alpha/rendered/main-alb.yaml
@@ -20,3 +20,5 @@ notificationSendit:
 argocdProxy:
   rateLimiting:
     enabled: true
+  trustedProxies:
+    enabled: true

--- a/environments/alpha/values.yaml
+++ b/environments/alpha/values.yaml
@@ -90,6 +90,8 @@ argocd:
     enabled: true
 
 argocdProxy:
+  trustedProxies:
+    enabled: true
   rateLimiting:
     enabled: true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced NGINX configuration to accurately display the real client IP address when accessed through trusted proxies. This ensures more reliable logging and IP-based features for users behind multiple proxy layers.
  * Added support for specifying trusted proxy IP ranges to improve client IP detection accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->