### PR TITLE
NET-275 enable rate limiting in gamma & delta

### DIFF
--- a/environments/delta/rendered/main-alb.yaml
+++ b/environments/delta/rendered/main-alb.yaml
@@ -16,3 +16,9 @@ appRegistryService:
 
 notificationSendit:
   disable: true
+
+argocdProxy:
+  rateLimiting:
+    enabled: true
+  trustedProxies:
+    enabled: true

--- a/environments/delta/values.yaml
+++ b/environments/delta/values.yaml
@@ -78,6 +78,12 @@ argocd:
   externalAccess:
     enabled: true
 
+argocdProxy:
+  trustedProxies:
+    enabled: true
+  rateLimiting:
+    enabled: true
+
 xchainMonitor:
   image:
     tag: "latest"

--- a/environments/gamma/rendered/main-alb.yaml
+++ b/environments/gamma/rendered/main-alb.yaml
@@ -16,3 +16,9 @@ appRegistryService:
 
 notificationSendit:
   disable: true
+
+argocdProxy:
+  rateLimiting:
+    enabled: true
+  trustedProxies:
+    enabled: true

--- a/environments/gamma/values.yaml
+++ b/environments/gamma/values.yaml
@@ -87,6 +87,12 @@ argocd:
   externalAccess:
     enabled: true
 
+argocdProxy:
+  trustedProxies:
+    enabled: true
+  rateLimiting:
+    enabled: true
+
 xchainMonitor:
   image:
     tag: "a2d43eb"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled rate limiting and trusted proxy support for ArgoCD proxy in both delta and gamma environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->