### PR TITLE
NET-275 increase argoCD rate limits

### DIFF
--- a/charts/main-alb/values.yaml
+++ b/charts/main-alb/values.yaml
@@ -11,8 +11,8 @@ argocdProxy:
   rateLimiting:
     enabled: false
     general:
-      rate: "10"
-      burst: "30"
+      rate: "50"
+      burst: "150"
     webhook:
-      rate: "5"
-      burst: "10"
+      rate: "10"
+      burst: "20"


### PR DESCRIPTION
Based on some testing, its possible to reach the limits refreshing argo a couple times, so should be increased to avoid accidental triggering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased rate limiting thresholds for both general and webhook requests, allowing higher request rates and burst capacities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->