### PR TITLE
NET-280 update git credential secret

### DIFF
--- a/charts/argocd/templates/secrets.yaml
+++ b/charts/argocd/templates/secrets.yaml
@@ -8,6 +8,10 @@ spec:
   secretStoreRef:
     name: gcp-secret-store
     kind: ClusterSecretStore
+  data:
+    - secretKey: sshkey
+      remoteRef:
+        key: "github-ssh-key"
   target:
     name: github-credentials
     creationPolicy: Owner
@@ -15,16 +19,12 @@ spec:
       type: Opaque
       metadata:
         labels:
-          argocd.argoproj.io/secret-type: repo-creds
+          argocd.argoproj.io/secret-type: repository
       data:
         type: "git"
-        url: "git@github.com:HereNotThere/argocd"
+        url: "git@github.com:HereNotThere/argocd.git"
         sshPrivateKey: "{{ .sshkey | toString }}"
         sshKnownHosts: |
           github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
           github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
           github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
-  data:
-    - secretKey: sshkey
-      remoteRef:
-        key: "github-ssh-key"


### PR DESCRIPTION
replacing credential template with direct link to argocd repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the git repository URL to ensure correct access.
  * Adjusted the label on the generated secret for improved compatibility.

* **Chores**
  * Rearranged the secret key mapping section within the manifest for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->