### PR TITLE
NET-280 update secret engine version for git-creds

### DIFF
--- a/charts/argocd/templates/secrets.yaml
+++ b/charts/argocd/templates/secrets.yaml
@@ -17,6 +17,7 @@ spec:
     creationPolicy: Owner
     template:
       type: Opaque
+      engineVersion: v2
       metadata:
         labels:
           argocd.argoproj.io/secret-type: repository


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret template configuration to explicitly specify engine version v2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->