### PR TITLE
Enable cold streams for notification service on alpha

### DIFF
--- a/environments/alpha/rendered/notification-service.yaml
+++ b/environments/alpha/rendered/notification-service.yaml
@@ -4,7 +4,7 @@
 
 apnsTownsAppIdentifier: com.towns.ios.alpha
 image:
-  tag: "5b14fcb"
+  tag: "cfa08d2"
 resources:
   limits:
     cpu: 1000m

--- a/environments/alpha/rendered/notification-service.yaml
+++ b/environments/alpha/rendered/notification-service.yaml
@@ -14,3 +14,6 @@ resources:
     memory: 7.5Gi
 
 logLevel: info
+
+notifications:
+  ColdStreamsEnabled: true

--- a/environments/alpha/values.yaml
+++ b/environments/alpha/values.yaml
@@ -26,6 +26,7 @@ notificationService:
       cpu: 1000m
       memory: 7.5Gi
   apnsTownsAppIdentifier: com.towns.ios.alpha
+  ColdStreamsEnabled: true
 
 notificationSendit:
   image:

--- a/environments/alpha/values.yaml
+++ b/environments/alpha/values.yaml
@@ -17,7 +17,7 @@ chains:
 
 notificationService:
   image:
-    tag: "5b14fcb"
+    tag: "cfa08d2"
   resources:
     requests:
       cpu: 1000m

--- a/templates/notification-service.j2
+++ b/templates/notification-service.j2
@@ -5,3 +5,6 @@ resources:
   {{ notificationService.resources | to_yaml | indent(2) }}
 
 logLevel: {{ notificationService.logLevel | default('info') | lower }}
+
+notifications:
+    ColdStreamsEnabled: {{ notificationService.ColdStreamsEnabled | default('false') | lower }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration option to enable or disable "ColdStreams" notifications for the notification service. This option is now available in the environment settings and reflected in the service's configuration.  
  * Updated the notification service to a new image version for improved performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->