### PR TITLE
Enable cold streams on alpha, gamma, delta

### DIFF
--- a/environments/alpha/rendered/notification-sendit.yaml
+++ b/environments/alpha/rendered/notification-sendit.yaml
@@ -14,3 +14,6 @@ resources:
     memory: 2Gi
 
 logLevel: info
+
+notifications:
+  ColdStreamsEnabled: true

--- a/environments/alpha/values.yaml
+++ b/environments/alpha/values.yaml
@@ -39,6 +39,7 @@ notificationSendit:
       cpu: 1000m
       memory: 7.5Gi
   apnsTownsAppIdentifier: com.towns.ios.sendit
+  ColdStreamsEnabled: true
 
 riverNode:
   image:

--- a/environments/delta/rendered/notification-sendit.yaml
+++ b/environments/delta/rendered/notification-sendit.yaml
@@ -14,3 +14,6 @@ resources:
     memory: 2Gi
 
 logLevel: info
+
+notifications:
+  ColdStreamsEnabled: true

--- a/environments/delta/rendered/notification-service.yaml
+++ b/environments/delta/rendered/notification-service.yaml
@@ -16,4 +16,4 @@ resources:
 logLevel: info
 
 notifications:
-  ColdStreamsEnabled: false
+  ColdStreamsEnabled: true

--- a/environments/delta/values.yaml
+++ b/environments/delta/values.yaml
@@ -25,6 +25,7 @@ notificationService:
       cpu: 1
       memory: 7.5Gi
   apnsTownsAppIdentifier: com.towns.ios.delta
+  ColdStreamsEnabled: true
   riverRegistryPageSize: 1500
 
 notificationSendit:
@@ -38,6 +39,7 @@ notificationSendit:
       cpu: 1
       memory: 7.5Gi
   apnsTownsAppIdentifier: com.towns.ios.sendit
+  ColdStreamsEnabled: true
 
 riverNode:
   image:

--- a/environments/gamma/rendered/notification-sendit.yaml
+++ b/environments/gamma/rendered/notification-sendit.yaml
@@ -14,3 +14,6 @@ resources:
     memory: 2Gi
 
 logLevel: info
+
+notifications:
+  ColdStreamsEnabled: true

--- a/environments/gamma/rendered/notification-service.yaml
+++ b/environments/gamma/rendered/notification-service.yaml
@@ -16,4 +16,4 @@ resources:
 logLevel: info
 
 notifications:
-  ColdStreamsEnabled: false
+  ColdStreamsEnabled: true

--- a/environments/gamma/values.yaml
+++ b/environments/gamma/values.yaml
@@ -26,6 +26,7 @@ notificationService:
     limits:
       cpu: 1
       memory: 7Gi
+  ColdStreamsEnabled: true
 
 notificationSendit:
   image:
@@ -38,6 +39,7 @@ notificationSendit:
       cpu: 1
       memory: 7Gi
   apnsTownsAppIdentifier: com.towns.ios.sendit
+  ColdStreamsEnabled: true
 
 riverNode:
   image:

--- a/templates/notification-sendit.j2
+++ b/templates/notification-sendit.j2
@@ -5,3 +5,6 @@ resources:
   {{ notificationSendit.resources | to_yaml | indent(2) }}
 
 logLevel: {{ notificationSendit.logLevel | default('info') | lower }}
+
+notifications:
+    ColdStreamsEnabled: {{ notificationSendit.ColdStreamsEnabled | default('false') | lower }}


### PR DESCRIPTION
Tested in alpha


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration option to enable or disable "ColdStreams" for notification services across multiple environments.
  * The "ColdStreams" feature is now enabled by default in the affected environments for both notification services.

* **Chores**
  * Updated configuration and template files to support the new "ColdStreamsEnabled" flag for improved environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->