### PR TITLE
NET-303 scale down archive nodes from 3 to 1

### DIFF
--- a/environments/omega/rendered/river-node.yaml
+++ b/environments/omega/rendered/river-node.yaml
@@ -59,30 +59,6 @@ nodes:
     image:
       tag: "23b906d"
 
-  - nodeType: archive
-    nodeNumber: 2
-    hostname: archive2.nodes.omega.towns.com
-    runMode: archive
-    standbyOnStart: false
-    dbUser: archive2
-    ddTags: "env:omega, service: river-node, mode: archive, node_url: https://archive2.nodes.omega.towns.com"
-    nodeUrl: https://archive2.nodes.omega.towns.com
-    migrationStatus: done
-    image:
-      tag: "23b906d"
-
-  - nodeType: archive
-    nodeNumber: 3
-    hostname: archive3.nodes.omega.towns.com
-    runMode: archive
-    standbyOnStart: false
-    dbUser: archive3
-    ddTags: "env:omega, service: river-node, mode: archive, node_url: https://archive3.nodes.omega.towns.com"
-    nodeUrl: https://archive3.nodes.omega.towns.com
-    migrationStatus: done
-    image:
-      tag: "23b906d"
-
 race: false
 
 logLevel: info

--- a/environments/omega/values.yaml
+++ b/environments/omega/values.yaml
@@ -48,7 +48,7 @@ riverNode:
   riverRegistryPageSize: 3000
   useRpcGateway: true
   numStreamNodes: 3
-  numArchiveNodes: 3
+  numArchiveNodes: 1
 
   gotraceback: "crash"
   apmEnabled: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the number of configured archive nodes from three to one in the environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->